### PR TITLE
Add argument `alias` to update command

### DIFF
--- a/commands/update.js
+++ b/commands/update.js
@@ -36,6 +36,8 @@ class UpdateTemplateCommand extends BaseCommand {
             /.*/
         );
 
+        cmd.argument('[alias]', 'Save template with [alias].', /.*/);
+
         cmd.option('--skip-cache',
             'Force download template even if its cached.',
             prog.BOOL,


### PR DESCRIPTION
This PR closes #17 by adding the `alias` argument to the update command